### PR TITLE
Namespace javolution -> org.javolution

### DIFF
--- a/src/main/java/org/javolution/context/ComputeContext.java
+++ b/src/main/java/org/javolution/context/ComputeContext.java
@@ -78,7 +78,7 @@ import org.javolution.osgi.internal.OSGiServices;
 
  * By default, the best GPU device with support for {@link ComputeContext#DOUBLE_PRECISION_REQUIRED double precision 
  * floating-point} is selected. If your GPU does not have such support, the CPU device is chosen. 
- * For complex data structures shared between OpenCL and Java, {@link javolution.io.Struct} is recommended.
+ * For complex data structures shared between OpenCL and Java, {@link org.javolution.io.Struct} is recommended.
  *     
  * *Thread-Safety:* As for any {@link AbstractContext context}, compute contexts are inherently thread-safe 
  * (each thread entering a context has its own context instance); but nesting a {@link ConcurrentContext} within
@@ -205,7 +205,7 @@ public abstract class ComputeContext extends AbstractContext {
     /**
      * Indicates if support for double precision floating-point is required
      * (default {@code true}). Running with the option {@code 
-     * -Djavolution.context.ComputeContext#DOUBLE_PRECISION_REQUIRED=false}
+     * -Dorg.javolution.context.ComputeContext#DOUBLE_PRECISION_REQUIRED=false}
      * disables the requirement to select a device supporting 
      * double precision.
      */

--- a/src/main/java/org/javolution/context/ComputeContext.java
+++ b/src/main/java/org/javolution/context/ComputeContext.java
@@ -25,7 +25,9 @@ import org.javolution.osgi.internal.OSGiServices;
  * (to the heap). Device operations are asynchronous and performed in parallel whenever possible
  * (based on inputs parameters dependencies). Synchronisation with host (java) is performed when buffers
  * are read/exported (typically to retrieve the calculations results).
- * 
+ * <pre>
+ *
+ * {@code
  * ```java
  * FloatVector result;
  * ComputeContext ctx = ComputeContext.enter();
@@ -60,7 +62,7 @@ import org.javolution.osgi.internal.OSGiServices;
  *         sum.execute(); // Executes in parallel with others kernels. 
  *         return result; 
  *     }
- *     @Override
+ *     @literal @Override
  *     public void export() { // Moves to global memory. 
  *         buffer.export();
  *     }
@@ -75,7 +77,8 @@ import org.javolution.osgi.internal.OSGiServices;
  *     }  
  * }
  * ```
-
+ * }}
+ * </pre>
  * By default, the best GPU device with support for {@link ComputeContext#DOUBLE_PRECISION_REQUIRED double precision 
  * floating-point} is selected. If your GPU does not have such support, the CPU device is chosen. 
  * For complex data structures shared between OpenCL and Java, {@link org.javolution.io.Struct} is recommended.

--- a/src/main/java/org/javolution/context/ConcurrentContext.java
+++ b/src/main/java/org/javolution/context/ConcurrentContext.java
@@ -153,7 +153,7 @@ public abstract class ConcurrentContext extends AbstractContext {
     /**
      * Holds the maximum concurrency (default: `Runtime.getRuntime().availableProcessors() - 1`).
      * The maximum concurrency is configurable. 
-     * For example, the JVM option `-Djavolution.context.ConcurrentContext#CONCURRENCY=0` disables concurrency. 
+     * For example, the JVM option `-Dorg.javolution.context.ConcurrentContext#CONCURRENCY=0` disables concurrency.
      */
     public static final Configurable<Integer> CONCURRENCY = new Configurable<Integer>() {
         @Override

--- a/src/main/java/org/javolution/context/FormatContext.java
+++ b/src/main/java/org/javolution/context/FormatContext.java
@@ -11,17 +11,17 @@ package org.javolution.context;
 /**
  * The parent class for all serializer/deserializer contexts. The context format type (plain text, XML, JSON, ...) 
  * is specified by sub-classes. Classes may identify the plain text format through the 
- * {@link javolution.text.DefaultTextFormat DefaultTextFormat} annotation
+ * {@link org.javolution.text.DefaultTextFormat DefaultTextFormat} annotation
  * or the default XML format through the 
- * {@link javolution.xml.DefaultXMLFormat DefaultXMLFormat} annotation.
+ * {@link org.javolution.xml.DefaultXMLFormat DefaultXMLFormat} annotation.
  * 
  * ```java
  * {@literal@}DefaultTextFormat(Complex.Cartesian.class)
  * {@literal@}DefaultXMLFormat(Complex.XML.class)
  * public Complex {
- *     public static final class Cartesian extends javolution.text.TextFormat<Complex> { ... }
- *     public static final class Polar extends javolution.text.TextFormat<Complex> { ... }
- *     public static final class XML extends javolution.text.XMLFormat<Complex> { ... }
+ *     public static final class Cartesian extends org.javolution.text.TextFormat<Complex> { ... }
+ *     public static final class Polar extends org.javolution.text.TextFormat<Complex> { ... }
+ *     public static final class XML extends org.javolution.text.XMLFormat<Complex> { ... }
  *     ...
  * }
  * ```

--- a/src/main/java/org/javolution/context/FormatContext.java
+++ b/src/main/java/org/javolution/context/FormatContext.java
@@ -16,8 +16,8 @@ package org.javolution.context;
  * {@link org.javolution.xml.DefaultXMLFormat DefaultXMLFormat} annotation.
  * 
  * ```java
- * {@literal@}DefaultTextFormat(Complex.Cartesian.class)
- * {@literal@}DefaultXMLFormat(Complex.XML.class)
+ * {@literal @}DefaultTextFormat(Complex.Cartesian.class)
+ * {@literal @}DefaultXMLFormat(Complex.XML.class)
  * public Complex {
  *     public static final class Cartesian extends org.javolution.text.TextFormat<Complex> { ... }
  *     public static final class Polar extends org.javolution.text.TextFormat<Complex> { ... }

--- a/src/main/java/org/javolution/context/LocalContext.java
+++ b/src/main/java/org/javolution/context/LocalContext.java
@@ -19,7 +19,7 @@ import org.javolution.osgi.internal.OSGiServices;
  * and does not need to be specified for each operation.
  * 
  * ```java
- * import javolution.context.LocalContext.Parameter;
+ * import org.javolution.context.LocalContext.Parameter;
  * public class ModuloInteger extends Number {
  *     public static final Parameter<Integer> MODULO = new Parameter<Integer>() {
  *          protected Integer getDefault() { return -1; }

--- a/src/main/java/org/javolution/context/LogContext.java
+++ b/src/main/java/org/javolution/context/LogContext.java
@@ -89,7 +89,7 @@ public abstract class LogContext extends AbstractContext {
 
     /**
      * Holds the default logging level (<code>INFO</code>). This level is configurable. For example, running with 
-     * the option `-Djavolution.context.LogContext#DEFAULT_LEVEL=WARNING` causes the debug/info not to be logged. 
+     * the option `-Dorg.javolution.context.LogContext#DEFAULT_LEVEL=WARNING` causes the debug/info not to be logged.
      */
     public static final Configurable<Level> DEFAULT_LEVEL = new Configurable<Level>() {
         @Override

--- a/src/main/java/org/javolution/context/LogContext.java
+++ b/src/main/java/org/javolution/context/LogContext.java
@@ -119,7 +119,7 @@ public abstract class LogContext extends AbstractContext {
     /**
      * Logs the specified debug messages.
      * 
-     * @param message 
+     * @param messages to log
      */
     public static void debug(Object... messages) {
         currentLogContext().log(Level.DEBUG, null, messages);
@@ -128,7 +128,7 @@ public abstract class LogContext extends AbstractContext {
     /**
      * Logs the specified info messages.
      * 
-     * @param message 
+     * @param messages to log
      */
     public static void info(Object... messages) {
         currentLogContext().log(Level.INFO, null, messages);
@@ -137,7 +137,7 @@ public abstract class LogContext extends AbstractContext {
     /**
      * Logs the specified warning messages.
      * 
-     * @param message 
+     * @param messages to log
      */
     public static void warning(Object... messages) {
         currentLogContext().log(Level.WARNING, null, messages);
@@ -146,7 +146,7 @@ public abstract class LogContext extends AbstractContext {
     /**
      * Logs the specified error messages.
      * 
-     * @param message
+     * @param messages to log
      */
     public static void error(Object... messages) {
        currentLogContext().log(Level.ERROR, null, messages);
@@ -154,8 +154,9 @@ public abstract class LogContext extends AbstractContext {
 
     /**
      * Logs the specified error and error messages.
-     * 
-     * @param message
+     *
+     * @param error cause
+     * @param messages to log
      */
     public static void error(Throwable error, Object... messages) {
        currentLogContext().log(Level.ERROR, error, messages);

--- a/src/main/java/org/javolution/context/package-info.java
+++ b/src/main/java/org/javolution/context/package-info.java
@@ -1,5 +1,5 @@
 /**
-<p> Run-time {@link javolution.context.AbstractContext contexts} to facilitate 
+<p> Run-time {@link org.javolution.context.AbstractContext contexts} to facilitate
     separation of concerns and achieve higher level of performance and flexibility.</p>
 
 ## Separation of Concerns
@@ -26,7 +26,7 @@ Separation of concerns can be addressed through "Aspect Programming",
 but there is a rather simpler solution <b>"Context Programming"</b>!</p>
        
 It does not require any particular tool, it basically says that every threads 
-has a {@link javolution.context.AbstractContext context} which can be customized by someone else
+has a {@link org.javolution.context.AbstractContext context} which can be customized by someone else
 (the one who knows what to do, when running OSGi it is typically a separate bundle).
 Then, your code looks a lot cleaner and is way more flexible as you don't have
 to worry about logging, security, performance etc. in your low level methods. 
@@ -39,37 +39,37 @@ void myMethod() {
 }
 ```       
 
-Used properly <i><b>J</b>avolution</i>'s {@link javolution.context.AbstractContext contexts}
+Used properly <i><b>J</b>avolution</i>'s {@link org.javolution.context.AbstractContext contexts}
 greatly facilitate the separation of concerns. Contexts are fully 
 integrated with OSGi (they are published services). Applications 
 may dynamically plug-in the "right context" using OSGi mechanisms. 
-For example, the {@link javolution.context.SecurityContext SecurityContext} might only be known at runtime.
+For example, the {@link org.javolution.context.SecurityContext SecurityContext} might only be known at runtime.
      
 ## Predefined Contexts
 
 `Javolution` provides several useful runtime contexts:
 
-- {@link javolution.context.ComputeContext ComputeContext} - To take advantage of computing devices (GPUs)
+- {@link org.javolution.context.ComputeContext ComputeContext} - To take advantage of computing devices (GPUs)
   and to reduce heap allocations.
-- {@link javolution.context.ConcurrentContext ConcurrentContext} - To take advantage of concurrent algorithms
+- {@link org.javolution.context.ConcurrentContext ConcurrentContext} - To take advantage of concurrent algorithms
   on multi-cores systems.
-- {@link javolution.context.LogContext LogContext} - To log events according to the runtime environment 
+- {@link org.javolution.context.LogContext LogContext} - To log events according to the runtime environment
   (e.g. {@link org.osgi.service.log.LogService} when running OSGi).     
-- {@link javolution.context.LocalContext LocalContext} - To define locally  scoped environment settings.
-- {@link javolution.context.ComputeContext ComputeContext} - To accelerate computations using GPUs device (if present).
-- {@link javolution.context.SecurityContext SecurityContext} - To address application-level security concerns.
-- {@link javolution.context.StorageContext StorageContext} - To store/retrieve your persistent data/dataset.
-- {@link javolution.context.FormatContext FormatContext} - For plugable objects parsing/formatting.
-   Such as  {@link javolution.text.TextContext TextContext} for plain text, 
-   or {@link javolution.xml.XMLContext XMLContext} for XML serialization/deserialization.
-- {@link javolution.context.StorageContext StorageContext} - To store/retrieve your persistent data/dataset.
+- {@link org.javolution.context.LocalContext LocalContext} - To define locally  scoped environment settings.
+- {@link org.javolution.context.ComputeContext ComputeContext} - To accelerate computations using GPUs device (if present).
+- {@link org.javolution.context.SecurityContext SecurityContext} - To address application-level security concerns.
+- {@link org.javolution.context.StorageContext StorageContext} - To store/retrieve your persistent data/dataset.
+- {@link org.javolution.context.FormatContext FormatContext} - For plugable objects parsing/formatting.
+   Such as  {@link org.javolution.text.TextContext TextContext} for plain text,
+   or {@link org.javolution.xml.XMLContext XMLContext} for XML serialization/deserialization.
+- {@link org.javolution.context.StorageContext StorageContext} - To store/retrieve your persistent data/dataset.
 - ...add your own !
 
   
 
 ## FAQ
 
-1. Thanks for providing GPUs accelerated {@link javolution.context.ComputeContext ComputeContext} but why 
+1. Thanks for providing GPUs accelerated {@link org.javolution.context.ComputeContext ComputeContext} but why
    is it recommended to enter/exit a context scope in order to use it ?
 > ComputeContext allocates buffers in the device memory (CPU/GPU), these buffers are released either through 
 > garbage collection or immediately when exiting the context scope. Freeing the resources immediately ensures
@@ -93,7 +93,7 @@ public static void main(String... args) {
 2. In my application I create new threads on-the-fly and I would like them to inherit the current context environment. 
    How can I do that?
 > Context is automatically inherited when performing concurrent executions using 
-> {@link javolution.context.ConcurrentContext ConcurrentContext}. If you create new threads yourself 
+> {@link org.javolution.context.ConcurrentContext ConcurrentContext}. If you create new threads yourself
 > you can easily setup their context as shown below.
 
 ```java

--- a/src/main/java/org/javolution/doc-files/overview.html
+++ b/src/main/java/org/javolution/doc-files/overview.html
@@ -1,5 +1,5 @@
 <BODY>
-<H2><B><I><SPAN CLASS="style0">J</SPAN><SPAN CLASS="style1">avolution</I></B></SPAN> - Java<SUP>TM</SUP> Solution for Real-Time and Embedded Systems.</H2>
+<H2><B><I><SPAN CLASS="style0">J</SPAN><SPAN CLASS="style1">avolution</SPAN></I></B> - Java<SUP>TM</SUP> Solution for Real-Time and Embedded Systems.</H2>
 
 <a name="license"></a>
 <h3><b>License:</b></h3>

--- a/src/main/java/org/javolution/doc-files/overview.html
+++ b/src/main/java/org/javolution/doc-files/overview.html
@@ -7,7 +7,7 @@
     provided that copyright notices are preserved (the full license text can be found 
     <a href="http://javolution.org/LICENSE.txt">here</a>).</p>
 <p> <b><i>Javolution</i></b>'s users are encouraged to show their support with the
-    <a href="http://javolution.org"><img src="http://javolution.org/src/site/css/img/javolution.png"></a> button.</p>
+    <a href="http://javolution.org"><img src="http://javolution.org/src/site/css/img/org.javolution.png"></a> button.</p>
 
 <a name="overview"></a>
 <h3><b>Overview:</b></h3>
@@ -45,7 +45,7 @@ from the Java<sup>TM</sup> core library and making the Java<sup>TM</sup> platfor
 <p> Or as a standard Java library (does not require OSGi runtime).</p>
 
 <div style="background: #ffffff; overflow:auto;width:auto;color:black;background:white;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre style="margin: 0; line-height: 125%">
-<span style="color: #7F0055; font-weight: bold">import</span> javolution.osgi.internal.OSGiServices;
+<span style="color: #7F0055; font-weight: bold">import</span> org.javolution.osgi.internal.OSGiServices;
 <span style="color: #7F0055; font-weight: bold">public</span> <span style="color: #7F0055; font-weight: bold">class</span> Main {
     <span style="color: #7F0055; font-weight: bold">public</span> <span style="color: #7F0055; font-weight: bold">static</span> <span style="color: #7F0055; font-weight: bold">void</span> main(String[] args) <span style="color: #7F0055; font-weight: bold">throws</span> XMLStreamException {
         XMLInputFactory factory = OSGiServices.getXMLInputFactory();  
@@ -64,17 +64,17 @@ from the Java<sup>TM</sup> core library and making the Java<sup>TM</sup> platfor
       <td style="vertical-align: top; text-align: center;"><span style="font-weight: bold;">Description</span></td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.xml.stream.XMLInputFactory}</td>
+      <td style="vertical-align: top;">{@link org.javolution.xml.stream.XMLInputFactory}</td>
       <td style="vertical-align: top;">StAX-like version of javax.xml.stream.XMLInputFactory avoiding {@code String} allocations.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.xml.stream.XMLOutputFactory}</td>
+      <td style="vertical-align: top;">{@link org.javolution.xml.stream.XMLOutputFactory}</td>
       <td style="vertical-align: top;">StAX-like version of javax.xml.stream.XMLOutputFactory using {@code CharSequence} instead of {@code String}</td>
     </tr>
   </tbody>
 </table>
 <p> These services can be accessed through the standard OSGi registry 
-      or using {@code javolution.osgi.internal.OSGiServices} when running outside OSGi.</p>
+      or using {@code org.javolution.osgi.internal.OSGiServices} when running outside OSGi.</p>
 <p><b><i>Javolution</i></b> listen to the following OSGi services.</p>
 <table cellpadding="2" cellspacing="2" border="1" style="text-align: left; width: 1000px;">
   <tbody>
@@ -87,36 +87,36 @@ from the Java<sup>TM</sup> core library and making the Java<sup>TM</sup> platfor
       <td style="vertical-align: top;">OSGi service to log messages.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.LogContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.LogContext}</td>
       <td style="vertical-align: top;">Service to support asynchronous logging.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.ConcurrentContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.ConcurrentContext}</td>
       <td style="vertical-align: top;">Service to support concurrent executions.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.LocalContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.LocalContext}</td>
       <td style="vertical-align: top;">Service to support locally scoped settings.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.ComputeContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.ComputeContext}</td>
       <td style="vertical-align: top;">Service for executing kernels functions on computing devices 
       (OpenCL compliant).</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.SecurityContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.SecurityContext}</td>
       <td style="vertical-align: top;">Service granting security authorizations.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.context.StorageContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.context.StorageContext}</td>
       <td style="vertical-align: top;">Service to store/retrieve persistent data/dataset.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.text.TextContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.text.TextContext}</td>
       <td style="vertical-align: top;">Service to support text parsing/formatting.</td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link javolution.xml.XMLContext}</td>
+      <td style="vertical-align: top;">{@link org.javolution.xml.XMLContext}</td>
       <td style="vertical-align: top;">Service to support XML serialization/deserialization.</td>
     </tr>
   </tbody>

--- a/src/main/java/org/javolution/io/Struct.java
+++ b/src/main/java/org/javolution/io/Struct.java
@@ -784,8 +784,7 @@ public class Struct {
      * @param  bitOffset the bit start position in the Struct.
      * @param  bitSize the number of bits.
      * @return the specified bits read as a signed long.
-     * @throws IllegalArgumentException if
-     *         {@code(bitOffset + bitSize - 1) / 8 >= this.size()}
+     * @throws IllegalArgumentException if {@code (bitOffset + bitSize - 1) / 8 >= this.size()}
      */
     public long readBits(int bitOffset, int bitSize) {
         if ((bitOffset + bitSize - 1) >> 3 >= this.size()) throw new IllegalArgumentException(
@@ -837,7 +836,7 @@ public class Struct {
      * @param  bitOffset the bit start position in the Struct.
      * @param  bitSize the number of bits.
      * @throws IllegalArgumentException if
-     *         {@code(bitOffset + bitSize - 1) / 8 >= this.size()}
+     *         {@code (bitOffset + bitSize - 1) / 8 >= this.size()}
      */
     public void writeBits(long value, int bitOffset, int bitSize) {
         if ((bitOffset + bitSize - 1) >> 3 >= this.size()) throw new IllegalArgumentException(

--- a/src/main/java/org/javolution/io/package-info.java
+++ b/src/main/java/org/javolution/io/package-info.java
@@ -1,6 +1,6 @@
 /**
 <p> Utility classes for input and output such as 
-    {@link javolution.io.Struct Struct} and {@link javolution.io.Union Union}
+    {@link org.javolution.io.Struct Struct} and {@link org.javolution.io.Union Union}
     for direct interoperability with C/C++.</p>
  */
 package org.javolution.io;

--- a/src/main/java/org/javolution/lang/Configurable.java
+++ b/src/main/java/org/javolution/lang/Configurable.java
@@ -136,7 +136,7 @@ public abstract class Configurable<T> {
      * the {@link #parse parsed} value of the property supersedes the 
      * {@link #getDefault() default} value of this configurable. 
      * For example, running the JVM with
-     * the option {@code -Djavolution.context.ConcurrentContext#CONCURRENCY=0} 
+     * the option {@code -Dorg.javolution.context.ConcurrentContext#CONCURRENCY=0}
      * disables concurrency support.
      */
     public Configurable() {
@@ -174,7 +174,7 @@ public abstract class Configurable<T> {
     /**
      * Returns this configurable name. By convention, the name of the 
      * configurable is the name of the static field holding the
-     * configurable (e.g. "javolution.context.ConcurrentContext#CONCURRENCY").
+     * configurable (e.g. "org.javolution.context.ConcurrentContext#CONCURRENCY").
      * This method should be overridden if the enclosing class needs to be 
      * impervious to obfuscation or if the enclosing class defines multiple 
      * configurable fields.

--- a/src/main/java/org/javolution/lang/Configurable.java
+++ b/src/main/java/org/javolution/lang/Configurable.java
@@ -36,7 +36,7 @@ import org.javolution.text.TextContext;
  * ```java
  * class Document {
  *     public static final Configurable<Font> FONT = new Configurable<Font>() {
- *         {@literal@}Override
+ *         {@literal @}Override
  *         protected Font getDefault() { 
  *             new Font("Arial", Font.BOLD, 18);
  *         }

--- a/src/main/java/org/javolution/lang/Index.java
+++ b/src/main/java/org/javolution/lang/Index.java
@@ -35,7 +35,7 @@ import org.javolution.text.TypeFormat;
  * 
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @version 6.1, February 25, 2014
- * @see javolution.util.function.Indexer
+ * @see org.javolution.util.function.Indexer
  */
 @Realtime
 @DefaultTextFormat(Index.Format.class)
@@ -62,7 +62,7 @@ public final class Index extends Number implements Comparable<Index>, Immutable 
     /**
      * Holds the number of unique preallocated instances (default {@code 1024}). 
      * This number is configurable, for example with
-     * {@code -Djavolution.util.Index#UNIQUE=0} there is no unique instance.
+     * {@code -Dorg.javolution.util.Index#UNIQUE=0} there is no unique instance.
      */
     public static final Configurable<Integer> UNIQUE = new Configurable<Integer>() {
 

--- a/src/main/java/org/javolution/lang/Initializer.java
+++ b/src/main/java/org/javolution/lang/Initializer.java
@@ -23,7 +23,7 @@ import org.javolution.context.LogContext;
  * 
  * <p> Javolution activator initialize {@link Realtime} classes when started.
  *     When running outside OSGi the method
- *     {@code javolution.osgi.internal.OSGiServices.initializeRealtimeClasses()}
+ *     {@code org.javolution.osgi.internal.OSGiServices.initializeRealtimeClasses()}
  *     can be used to that effect..</p> 
  * 
  * <p> Class loading can be performed in a lazy manner and therefore some parts 

--- a/src/main/java/org/javolution/lang/MathLib.java
+++ b/src/main/java/org/javolution/lang/MathLib.java
@@ -140,7 +140,7 @@ public final class MathLib {
      * 
      * @param x the first positive integer value.
      * @param y the second positive integer value.
-     * @param y the third positive integer value.
+     * @param z the third positive integer value.
      * @return the corresponding morton code.
      * @see <a href="http://en.wikipedia.org/wiki/Z-order_curve">
      *       Wikipedia: Z-order curve</a>

--- a/src/main/java/org/javolution/text/CharArray.java
+++ b/src/main/java/org/javolution/text/CharArray.java
@@ -463,7 +463,7 @@ public final class CharArray implements CharSequence, Comparable<CharSequence> {
      * Returns the <code>float</code> represented by this character array.
      *
      * @return the corresponding <code>float</code> value.
-     * @return <code>TypeFormat.parseFloat(this)</code>
+     *         <code>TypeFormat.parseFloat(this)</code>
      * @throws NumberFormatException if this character sequence
      *         does not contain a parsable <code>float</code>.
      */

--- a/src/main/java/org/javolution/text/DefaultTextFormat.java
+++ b/src/main/java/org/javolution/text/DefaultTextFormat.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  * Specifies the default text format of a class (for parsing/formatting).
  *  
  * The default format is typically used by the {@link Object#toString()} method and can be locally overridden in 
- * the scope of a {@link javolution.text.TextContext TextContext}.
+ * the scope of a {@link org.javolution.text.TextContext TextContext}.
  *     
  * ```java
  * ​@DefaultTextFormat(Complex.Cartesian.class) 

--- a/src/main/java/org/javolution/text/TextBuilder.java
+++ b/src/main/java/org/javolution/text/TextBuilder.java
@@ -97,7 +97,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  index the index of the character.
      * @return the character at the specified index.
      * @throws IndexOutOfBoundsException if 
-     *         {@code(index < 0) || (index >= this.length())}
+     *         {@code (index < 0) || (index >= this.length())}
      */
     public final char charAt(int index) {
         if (index >= _length)
@@ -113,7 +113,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param srcEnd this text end index (not included).
      * @param dst the destination array to copy the data into.
      * @param dstBegin the offset into the destination array. 
-     * @throws IndexOutOfBoundsException if {@code(srcBegin < 0) ||
+     * @throws IndexOutOfBoundsException if {@code (srcBegin < 0) ||
      *  (dstBegin < 0) || (srcBegin > srcEnd) || (srcEnd > this.length())
      *  || ((dstBegin + srcEnd - srcBegin) >  dst.length)}
      */
@@ -136,7 +136,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      *
      * @param index the index of the character to modify.
      * @param c the new character. 
-     * @throws IndexOutOfBoundsException if {@code(index < 0) || 
+     * @throws IndexOutOfBoundsException if {@code (index < 0) ||
      *          (index >= this.length())}
      */
     public final void setCharAt(int index, char c) {
@@ -150,7 +150,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      *  setLength(newLength, '\u0000')}.
      *
      * @param newLength the new length of this builder.
-     * @throws IndexOutOfBoundsException if {@code(newLength < 0)}
+     * @throws IndexOutOfBoundsException if {@code (newLength < 0)}
      */
     public final void setLength(int newLength) {
         setLength(newLength, '\u0000');
@@ -163,7 +163,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      *
      * @param newLength the new length of this builder.
      * @param fillChar the character to be appended if required.
-     * @throws IndexOutOfBoundsException if {@code(newLength < 0)}
+     * @throws IndexOutOfBoundsException if {@code (newLength < 0)}
      */
     public final void setLength(int newLength, char fillChar) {
         if (newLength < 0)
@@ -183,7 +183,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  start the index of the first character inclusive.
      * @param  end the index of the last character exclusive.
      * @return a character sequence.
-     * @throws IndexOutOfBoundsException if {@code(start < 0) || (end < 0) ||
+     * @throws IndexOutOfBoundsException if {@code (start < 0) || (end < 0) ||
      *         (start > end) || (end > this.length())}
      */
     public final java.lang.CharSequence subSequence(int start, int end) {
@@ -240,7 +240,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  start the index of the first character to append.
      * @param  end the index after the last character to append.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(start < 0) || (end < 0) 
+     * @throws IndexOutOfBoundsException if {@code (start < 0) || (end < 0)
      *         || (start > end) || (end > csq.length())}
      */
     public final TextBuilder append(CharSequence csq, int start,
@@ -276,7 +276,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  start the index of the first character to append.
      * @param  end the index after the last character to append.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(start < 0) || (end < 0) 
+     * @throws IndexOutOfBoundsException if {@code (start < 0) || (end < 0)
      *         || (start > end) || (end > str.length())}
      */
     public final TextBuilder append(String str, int start, int end) {
@@ -321,7 +321,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  start the index of the first character to append.
      * @param  end the index after the last character to append.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(start < 0) || (end < 0) 
+     * @throws IndexOutOfBoundsException if {@code (start < 0) || (end < 0)
      *         || (start > end) || (end > txt.length())}
      */
     public final TextBuilder append(Text txt, int start, int end) {
@@ -362,7 +362,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param  offset the index of the first character to append.
      * @param  length the number of character to append.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(offset < 0) || 
+     * @throws IndexOutOfBoundsException if {@code (offset < 0) ||
      *         (length < 0) || ((offset + length) > chars.length)}
      */
     public final TextBuilder append(char chars[], int offset, int length) {
@@ -695,7 +695,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param index the insertion position.
      * @param csq the character sequence being inserted.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(index < 0) || 
+     * @throws IndexOutOfBoundsException if {@code (index < 0) ||
      *         (index > this.length())}
      */
     public final TextBuilder insert(int index, java.lang.CharSequence csq) {
@@ -733,7 +733,7 @@ public class TextBuilder implements Appendable, CharSequence, Serializable {
      * @param start the beginning index, inclusive.
      * @param end the ending index, exclusive.
      * @return <code>this</code>
-     * @throws IndexOutOfBoundsException if {@code(start < 0) || (end < 0) 
+     * @throws IndexOutOfBoundsException if {@code (start < 0) || (end < 0)
      *         || (start > end) || (end > this.length())}
      */
     public final TextBuilder delete(int start, int end) {

--- a/src/main/java/org/javolution/text/TextFormat.java
+++ b/src/main/java/org/javolution/text/TextFormat.java
@@ -28,8 +28,8 @@ import java.io.IOException;
  *     public String toString() {
  *         return TextContext.getFormat(Complex.class).format(this);
  *     }
- *     public static class Cartesian extends javolution.text.TextFormat<Complex> { ... }
- *     public static class Polar extends javolution.text.TextFormat<Complex> { ... }
+ *     public static class Cartesian extends org.javolution.text.TextFormat<Complex> { ... }
+ *     public static class Polar extends org.javolution.text.TextFormat<Complex> { ... }
  * }}</p>
  * 
  * <p> Text formats can be locally overridden.

--- a/src/main/java/org/javolution/text/package-info.java
+++ b/src/main/java/org/javolution/text/package-info.java
@@ -8,7 +8,7 @@
     <p> With Javolution 4.1, <code>double</code> formatting/parsing is lossless 
         and functionally the same as with the standard library. Parsing a character 
         sequence will always result in the same number whether it is performed with
-        {@link javolution.text.TypeFormat TypeFormat} or using <code>Double.parseDouble(String))</code>.
+        {@link org.javolution.text.TypeFormat TypeFormat} or using <code>Double.parseDouble(String))</code>.
         When formatting a <code>double</code> number, the number of digits output 
         is adjustable. The default (if the number of digits is unspecified) is <code>17</code> 
         or <code>16</code> when the the 16 digits representation  can be parsed back to
@@ -25,7 +25,7 @@ to conserve memory.</b>
     <p> It all depends of the size of the text to append (the actual size of the
          document being appended has almost no impact in both cases).</p>
     <p> If the text being appended is large (or arbitrarily large) then using 
-        {@link javolution.text.Text Text} is preferable.
+        {@link org.javolution.text.Text Text} is preferable.
 {@code
 class FastCollection<T> {
      public final Text toText() {

--- a/src/main/java/org/javolution/util/AbstractCollection.java
+++ b/src/main/java/org/javolution/util/AbstractCollection.java
@@ -47,7 +47,7 @@ import org.javolution.util.internal.collection.UnmodifiableCollectionImpl;
 /**
  * High-performance collection with {@link Realtime strict timing constraints}.
  * 
- * This class implements most of the {@link java.util.stream.Stream} functions and can be used directly 
+ * This class implements most of the {@code java.util.stream.Stream} functions and can be used directly
  * to perform sequential or parallel aggregate operations.
  * 
  * Instance of this class may use custom element comparators instead of the default object equality 

--- a/src/main/java/org/javolution/util/AbstractMap.java
+++ b/src/main/java/org/javolution/util/AbstractMap.java
@@ -48,7 +48,7 @@ import org.javolution.util.internal.map.ValuesImpl;
  * when comparing keys. This affects the behavior of the containsKey, put, remove, equals, and 
  * hashCode methods (see {@link java.util.IdentityHashMap} for such map in the standard library).
  * The {@link java.util.Map} contract is guaranteed to hold only for maps using {@link Equality#STANDARD} for 
- * {@link #equality() key comparisons}.
+ * equality key comparisons.
  *      
  * @param <K> the type of keys ({@code null} values are not supported)
  * @param <V> the type of values 

--- a/src/main/java/org/javolution/util/FastListIterator.java
+++ b/src/main/java/org/javolution/util/FastListIterator.java
@@ -9,6 +9,7 @@
 package org.javolution.util;
 
 import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 import org.javolution.util.function.Predicate;
 
@@ -55,7 +56,7 @@ public interface FastListIterator<E> extends FastIterator<E>, ListIterator<E> {
 
     /** 
      * Returns the next element.
-     * @throws NoSuchElementException if the iteration has no next element 
+     * @throws NoSuchElementException if the iteration has no next element
      */
     @Override
     E next();

--- a/src/main/java/org/javolution/util/FastMap.java
+++ b/src/main/java/org/javolution/util/FastMap.java
@@ -26,7 +26,7 @@ import org.javolution.util.function.Order;
  * space or performance.
  *  
  * ```java
- * import static javolution.util.function.Order.*;
+ * import static org.javolution.util.function.Order.*;
  * 
  * // Instances
  * FastMap<Foo, Bar> hashMap = new FastMap<Foo, Bar>(); // Arbitrary order (hash-based).

--- a/src/main/java/org/javolution/util/FastMap.java
+++ b/src/main/java/org/javolution/util/FastMap.java
@@ -16,7 +16,7 @@ import org.javolution.util.function.Indexer;
 import org.javolution.util.function.Order;
 
 /**
- * High-performance ordered map / multimap based upon fast-access {@link SparseArray}. 
+ * High-performance ordered map / multimap based upon fast-access {@link FastSet} ({@link FractalArray}).
  *     
  * Iterations order over map keys, values or entries is determined by the map {@link #keyOrder key order} except 
  * for specific views such as the {@link #linked linked view} for which iteration is performed according to the 
@@ -59,7 +59,6 @@ import org.javolution.util.function.Order;
  *                          "http://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock">readers-writer locks</a>.</li>
  *    <li>{@link #atomic} - Thread-safe view for which all reads are mutex-free and map updates 
  *                           (e.g. {@link #putAll putAll}) are atomic.</li>
- *    <li>{@link #reversed} - Reversed order view.</li>
  *    <li>{@link #linked} - View exposing each entry based on the {@link #put insertion} order in the view.</li>
  *    <li>{@link #unmodifiable} - View which does not allow for modification.</li>
  *    <li>{@link #valuesEquality} - View using the specified equality comparator for the map's values.</li>

--- a/src/main/java/org/javolution/util/FastSet.java
+++ b/src/main/java/org/javolution/util/FastSet.java
@@ -31,7 +31,7 @@ import org.javolution.util.internal.set.SortedSetImpl;
  * space or performance. 
  *     
  * ```java
- * import static javolution.util.function.Order.*;
+ * import static org.javolution.util.function.Order.*;
  * 
  * // Instances. 
  * FastSet<Foo> hashSet = new FastSet<Foo>(); // Arbitrary order (hash indexing) 

--- a/src/main/java/org/javolution/util/FractalArray.java
+++ b/src/main/java/org/javolution/util/FractalArray.java
@@ -74,8 +74,7 @@ public abstract class FractalArray<E> implements Cloneable, Serializable, Iterab
     
     /** 
      * Indicates if this fractal has no element different from {@code null}.
-     * 
-     * @param index the unsigned 32-bits index of the value to return.
+     *
      * @return {@code true} if all elements are {@code null}; {@code false} otherwise.
      */
     @Realtime(limit=CONSTANT)

--- a/src/main/java/org/javolution/util/function/package-info.java
+++ b/src/main/java/org/javolution/util/function/package-info.java
@@ -1,10 +1,10 @@
 /**
 <p> Basic functions for lambda expressions and method references.</p>
     Most often, functions do not have a state and can be called concurrently, 
-    as indicated by the annotation {@link javolution.lang.Parallelizable Parallelizable}.</p>
+    as indicated by the annotation {@link org.javolution.lang.Parallelizable Parallelizable}.</p>
     
 <p> Functions may take an arbitrary number of arguments through the use of the 
-    {@link javolution.lang.Binary Binary}/ {@link javolution.lang.Ternary Ternary} 
+    {@link org.javolution.lang.Binary Binary}/ {@link org.javolution.lang.Ternary Ternary}
     types or no argument at all using the standard {@link java.lang.Void} class.  
 [code]
 // Function indicating if two persons are married.

--- a/src/main/java/org/javolution/util/function/package-info.java
+++ b/src/main/java/org/javolution/util/function/package-info.java
@@ -1,7 +1,7 @@
 /**
 <p> Basic functions for lambda expressions and method references.</p>
     Most often, functions do not have a state and can be called concurrently, 
-    as indicated by the annotation {@link org.javolution.lang.Parallelizable Parallelizable}.</p>
+    as indicated by the annotation {@link org.javolution.annotations.Parallel}.</p>
     
 <p> Functions may take an arbitrary number of arguments through the use of the 
     {@link org.javolution.lang.Binary Binary}/ {@link org.javolution.lang.Ternary Ternary}

--- a/src/main/java/org/javolution/util/package-info.java
+++ b/src/main/java/org/javolution/util/package-info.java
@@ -1,5 +1,5 @@
 /**
- * High-performance collection classes with {@link org.javolution.lang.Realtime worst case execution time behavior}
+ * High-performance collection classes with {@link org.javolution.annotations.Realtime worst case execution time behavior}
  * documented.
  * 
  * Whereas Java current evolution leads to more and more classes being parts of the standard library; Javolution 
@@ -9,23 +9,25 @@
  * 
  * All collections classes support numerous views which can be chained:
  * 
- *  - {@link AbstractCollection#concat concat(Collection)} - View resulting of the concatenation of two collections.
- *  - {@link AbstractCollection#parallel parallel()} - View allowing parallel processing of {@link Parallel} operations.
- *  - {@link AbstractCollection#sequential sequential()} - View disallowing parallel processing of {@link Parallel} operations.
- *  - {@link AbstractCollection#unmodifiable unmodifiable()} - View which does not allow for modifications.
- *  - {@link AbstractCollection#shared shared()} - Thread-safe view based on <a href= "http://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock">
+ *  - {@link org.javolution.util.AbstractCollection#concat concat(Collection)} - View resulting of the concatenation of two collections.
+ *  - {@link org.javolution.util.AbstractCollection#parallel parallel()} - View allowing parallel processing of {@link org.javolution.annotations.Parallel} operations.
+ *  - {@link org.javolution.util.AbstractCollection#sequential sequential()} - View disallowing parallel processing of {@link org.javolution.annotations.Parallel} operations.
+ *  - {@link org.javolution.util.AbstractCollection#unmodifiable unmodifiable()} - View which does not allow for modifications.
+ *  - {@link org.javolution.util.AbstractCollection#shared shared()} - Thread-safe view based on <a href= "http://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock">
  *                      readers-writer locks</a>.
- *  - {@link AbstractCollection#atomic atomic()} - Thread-safe view for which all reads are mutex-free and collection updates 
- *                      (e.g. {@link AbstractCollection#addAll addAll}, {@link AbstractCollection#removeIf removeIf}, ...) are atomic.
- *  - {@link AbstractCollection#filter filter(Predicate)} - View exposing only the elements matching the specified filter and 
+ *  - {@link org.javolution.util.AbstractCollection#atomic atomic()} - Thread-safe view for which all reads are mutex-free and collection updates
+ *                      (e.g. {@link org.javolution.util.AbstractCollection#addAll addAll}, {@link org.javolution.util.AbstractCollection#removeIf removeIf}, ...) are atomic.
+ *  - {@link org.javolution.util.AbstractCollection#filter filter(Predicate)} - View exposing only the elements matching the specified filter and
  *                                         preventing elements not matching the specified filter from being added.
- *  - {@link AbstractCollection#map map(Function)} - View exposing elements through the specified mapping function.
- *  - {@link AbstractCollection#sorted(Comparator) sorted(Comparator)} - View exposing elements sorted according to the specified comparator.
- *  - {@link AbstractCollection#reversed reversed()} - View exposing elements in the reverse iterative order.
- *  - {@link AbstractCollection#distinct distinct()} - View exposing each element only once.
- *  - {@link AbstractCollection#linked linked()} - View exposing each element based on its {@link #add insertion} order.
- *  - {@link AbstractCollection#equality(Equality) equality(Equality)} - View using the specified comparator to test for element equality 
- *                                  (e.g. {@link AbstractCollection#contains}, {@link AbstractCollection#remove}, {@link AbstractCollection#distinct}, ...)
+ *  - {@link org.javolution.util.AbstractCollection#map map(Function)} - View exposing elements through the specified mapping function.
+ *  - {@link org.javolution.util.AbstractCollection#sorted(Comparator) sorted(Comparator)} - View exposing elements sorted according to the specified comparator.
+ *  - {@link org.javolution.util.AbstractCollection#reversed reversed()} - View exposing elements in the reverse iterative order.
+ *  - {@link org.javolution.util.AbstractCollection#distinct distinct()} - View exposing each element only once.
+ *  - {@link org.javolution.util.AbstractCollection#linked linked()} - View exposing each element based on its insertion order.
+ *  - {@link org.javolution.util.AbstractCollection#equality(Equality) equality(Equality)} - View using the specified comparator to test for element equality
+ *                                  (e.g. {@link org.javolution.util.AbstractCollection#contains},
+ *                                  {@link org.javolution.util.AbstractCollection#remove},
+ *                                  {@link org.javolution.util.AbstractCollection#distinct}, ...)
  * 
  * For all these views, the chaining order <b>does matter!</b>
  * 
@@ -44,8 +46,8 @@
  * List<String> threadSafe = names.linked().shared();  
  * List<String> threadUnsafe = names.shared().linked(); 
  * ``` 
-*  It should be noted that {@link AbstractCollection#unmodifiable unmodifiable} views *are not immutable*; 
- * {@link Immutable constant/immutable} collections (or maps) can only be obtained through the freeze method.
+*  It should be noted that {@link org.javolution.util.AbstractCollection#unmodifiable unmodifiable} views *are not immutable*;
+ * {@link org.javolution.lang.Immutable constant/immutable} collections (or maps) can only be obtained through the freeze method.
  * 
  * ```java
  * FastSet.Immutable<String> winners 

--- a/src/main/java/org/javolution/util/package-info.java
+++ b/src/main/java/org/javolution/util/package-info.java
@@ -1,5 +1,5 @@
 /**
- * High-performance collection classes with {@link javolution.lang.Realtime worst case execution time behavior} 
+ * High-performance collection classes with {@link org.javolution.lang.Realtime worst case execution time behavior}
  * documented.
  * 
  * Whereas Java current evolution leads to more and more classes being parts of the standard library; Javolution 

--- a/src/main/java/org/javolution/xml/DefaultXMLFormat.java
+++ b/src/main/java/org/javolution/xml/DefaultXMLFormat.java
@@ -18,9 +18,9 @@ import java.lang.annotation.Target;
 
 /**
  * <p> Specifies the default xml format of a class (for xml serialization/deserialization). 
- *     The default format is used by the {@link javolution.xml.XMLObjectReader}
- *     and {@link javolution.xml.XMLObjectWriter} classes. It can be locally overridden 
- *     in the scope of a {@link javolution.xml.XMLContext XMLContext}.</p>
+ *     The default format is used by the {@link org.javolution.xml.XMLObjectReader}
+ *     and {@link org.javolution.xml.XMLObjectWriter} classes. It can be locally overridden
+ *     in the scope of a {@link org.javolution.xml.XMLContext XMLContext}.</p>
  *     
  * [code]
  * @DefaultXMLFormat(Complex.XML.class) 

--- a/src/main/java/org/javolution/xml/DefaultXMLFormat.java
+++ b/src/main/java/org/javolution/xml/DefaultXMLFormat.java
@@ -22,8 +22,9 @@ import java.lang.annotation.Target;
  *     and {@link org.javolution.xml.XMLObjectWriter} classes. It can be locally overridden
  *     in the scope of a {@link org.javolution.xml.XMLContext XMLContext}.</p>
  *     
- * [code]
- * @DefaultXMLFormat(Complex.XML.class) 
+ * <pre>
+ * {@code
+ * @literal @DefaultXMLFormat(Complex.XML.class)
  * public class Complex {
  *     public Complex(double real, double imaginary) { ... }
  *     public double getReal() { ... }
@@ -40,8 +41,9 @@ import java.lang.annotation.Target;
  *              xml.setAttribute("imaginary", c.getImaginary());
  *          }
  *     };      
- * }[/code] 
- * 
+ * }
+ * }
+ * </pre>
  * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @version 6.0, July 21, 2013
  */

--- a/src/main/java/org/javolution/xml/QName.java
+++ b/src/main/java/org/javolution/xml/QName.java
@@ -188,8 +188,7 @@ public final class QName implements XMLSerializable, Immutable, CharSequence {
      *
      * @param  index the index of the character starting at <code>0</code>.
      * @return the character at the specified index of this character sequence.
-     * @throws IndexOutOfBoundsException  {@code if ((index < 0) || 
-     *         (index >= length))}
+     * @throws IndexOutOfBoundsException if {@code ((index < 0) || (index >= length))}
      */
     public char charAt(int index) {
         return _toString.charAt(index);

--- a/src/main/java/org/javolution/xml/XMLBinding.java
+++ b/src/main/java/org/javolution/xml/XMLBinding.java
@@ -213,7 +213,7 @@ public class XMLBinding implements XMLSerializable {
                 throw new XMLStreamException(
                         "Class "
                                 + classQName.getLocalName()
-                                + " not found (see javolution.lang.Reflection to support additional class loader)");
+                                + " not found (see org.javolution.lang.Reflection to support additional class loader)");
             _aliasToClass.put(classQName, cls);
             return cls;
         } catch (ClassNotFoundException ex) {

--- a/src/main/java/org/javolution/xml/XMLContext.java
+++ b/src/main/java/org/javolution/xml/XMLContext.java
@@ -15,14 +15,14 @@ import org.javolution.text.TextFormat;
 
 /**
  * <p> A context for XML parsing/formatting. This context provides 
- *     the {@link javolution.xml.XMLFormat XMLFormat} to parse/format objects
+ *     the {@link org.javolution.xml.XMLFormat XMLFormat} to parse/format objects
  *     of any class. If not superseded, the XML format for a class is specified
- *     by the {@link javolution.xml.DefaultXMLFormat DefaultXMLFormat} 
+ *     by the {@link org.javolution.xml.DefaultXMLFormat DefaultXMLFormat}
  *     annotation.</p>
  * <p> A XML context always returns the most specialized format. If a class 
  *     has no default format annotation (inherited or not), then the default 
  *     {@link java.lang.Object} format (with "value" attribute is 
- *     parsed/formatted using {@link javolution.text.TextContext current 
+ *     parsed/formatted using {@link org.javolution.text.TextContext current
  *     text format}) is returned. </p>
  *     <p>A predefined format exists for the following standard types:</p>
  *     <ul>

--- a/src/main/java/org/javolution/xml/XMLFormat.java
+++ b/src/main/java/org/javolution/xml/XMLFormat.java
@@ -134,7 +134,7 @@ public abstract class XMLFormat<T> {
      *
      * @param cls the class of the object to return.
      * @param xml the XML input element.
-     * @throws javolution.xml.stream.XMLStreamException Thrown when an error occurs while instantiating the specified class
+     * @throws org.javolution.xml.stream.XMLStreamException Thrown when an error occurs while instantiating the specified class
      * @return the object corresponding to the specified XML element.
      */
     public T newInstance(Class<? extends T> cls, InputElement xml)
@@ -153,7 +153,7 @@ public abstract class XMLFormat<T> {
      *
      * @param obj the object to format.
      * @param xml the <code>XMLElement</code> destination.
-     * @throws javolution.xml.stream.XMLStreamException Thrown when an error occurs while writing
+     * @throws org.javolution.xml.stream.XMLStreamException Thrown when an error occurs while writing
      */
     public abstract void write(T obj, OutputElement xml)
             throws XMLStreamException;
@@ -164,7 +164,7 @@ public abstract class XMLFormat<T> {
      * @param xml the XML element to parse.
      * @param obj the object created through {@link #newInstance}
      *        and to setup from the specified XML element.
-     * @throws javolution.xml.stream.XMLStreamException Thrown when an error occurs while reading
+     * @throws org.javolution.xml.stream.XMLStreamException Thrown when an error occurs while reading
      */
     public abstract void read(InputElement xml, T obj)
             throws XMLStreamException;
@@ -216,7 +216,7 @@ public abstract class XMLFormat<T> {
          * Indicates if more nested XML element can be read. This method 
          * positions the {@link #getStreamReader reader} at the start of the
          * next XML element to be read (if any).
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return <code>true</code> if there is more XML element to be read; 
          *         <code>false</code> otherwise.
          */
@@ -265,7 +265,7 @@ public abstract class XMLFormat<T> {
          * @param <T> type of object
          * @param name the local name of the next element.
          * @return the next nested object or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          */
         public <T> T get(String name) throws XMLStreamException {
             if (!hasNext()// Asserts isReaderAtNext == true
@@ -289,7 +289,7 @@ public abstract class XMLFormat<T> {
          * @param localName the local name.
          * @param uri the namespace URI or <code>null</code>.
          * @return the next nested object or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          */
         public <T> T get(String localName, String uri)
                 throws XMLStreamException {
@@ -318,7 +318,7 @@ public abstract class XMLFormat<T> {
          * @param name the local name of the element to match.
          * @param cls the class identifying the format of the object to return.
          * @return the next nested object or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          */
         public <T> T get(String name, Class<T> cls) throws XMLStreamException {
             if (!hasNext()// Asserts isReaderAtNext == true
@@ -341,7 +341,7 @@ public abstract class XMLFormat<T> {
          * @param uri the namespace URI or <code>null</code>.
          * @param cls the class identifying the format of the object to return.
          * @return the next nested object or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          */
         public <T> T get(String localName, String uri, Class<T> cls)
                 throws XMLStreamException {
@@ -400,10 +400,10 @@ public abstract class XMLFormat<T> {
 
         /**
          * Returns the content of a text-only element (equivalent to 
-         * {@link javolution.xml.stream.XMLStreamReader#getElementText 
+         * {@link org.javolution.xml.stream.XMLStreamReader#getElementText
          * getStreamReader().getElementText()}).
          *
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the element text content or an empty sequence if none.
          */
         public CharArray getText() throws XMLStreamException {
@@ -415,7 +415,7 @@ public abstract class XMLFormat<T> {
         /**
          * Returns the attributes for this XML input element.
          *
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the attributes mapping.
          */
         public Attributes getAttributes() throws XMLStreamException {
@@ -429,7 +429,7 @@ public abstract class XMLFormat<T> {
          * Searches for the attribute having the specified name.
          *
          * @param  name the name of the attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the value for the specified attribute or <code>null</code>
          *         if the attribute is not found.
          */
@@ -445,7 +445,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute.
          * @param  defaultValue a default value.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the value for the specified attribute or
          *         the <code>defaultValue</code> if the attribute is not found.
          */
@@ -460,7 +460,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>boolean</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -475,7 +475,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>char</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -496,7 +496,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>byte</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -512,7 +512,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>short</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -528,7 +528,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>int</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -544,7 +544,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>long</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -559,7 +559,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>float</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -574,7 +574,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the name of the attribute searched for.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the <code>double</code> value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -591,7 +591,7 @@ public abstract class XMLFormat<T> {
          * @param <T> type of the attribute
          * @param  name the name of the attribute.
          * @param  defaultValue the value returned if the attribute is not found.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs reading the xml stream
          * @return the parse value for the specified attribute or
          *         the default value if the attribute is not found.
          */
@@ -671,7 +671,7 @@ public abstract class XMLFormat<T> {
          * nested element of unknown type. 
          *
          * @param obj the object added as nested element or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void add(Object obj) throws XMLStreamException {
             if (obj == null) {
@@ -701,7 +701,7 @@ public abstract class XMLFormat<T> {
          *
          * @param obj the object added as nested element or <code>null</code>.
          * @param name the name of the nested element.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void add(Object obj, String name) throws XMLStreamException {
             if (obj == null)
@@ -733,7 +733,7 @@ public abstract class XMLFormat<T> {
          * @param obj the object added as nested element or <code>null</code>.
          * @param localName the local name of the nested element.
          * @param uri the namespace URI of the nested element.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void add(Object obj, String localName, String uri)
                 throws XMLStreamException {
@@ -766,7 +766,7 @@ public abstract class XMLFormat<T> {
          * @param obj the object added as nested element or <code>null</code>.
          * @param name the name of the nested element.
          * @param cls the class identifying the format of the specified object.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public <T> void add(T obj, String name, Class<T> cls)
                 throws XMLStreamException {
@@ -795,7 +795,7 @@ public abstract class XMLFormat<T> {
          * @param localName the local name of the nested element.
          * @param uri the namespace URI of the nested element.
          * @param cls the class identifying the format of the specified object.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public <T> void add(T obj, String localName, String uri, Class<T> cls)
                 throws XMLStreamException {
@@ -825,11 +825,11 @@ public abstract class XMLFormat<T> {
 
         /**
          * Adds the content of a text-only element (equivalent to {@link 
-         * javolution.xml.stream.XMLStreamWriter#writeCharacters(CharSequence) 
+         * org.javolution.xml.stream.XMLStreamWriter#writeCharacters(CharSequence)
          * getStreamWriter().writeCharacters(text)}).
          *
          * @param text the element text content or an empty sequence if none.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void addText(CharSequence text) throws XMLStreamException {
             _writer.writeCharacters(text);
@@ -840,7 +840,7 @@ public abstract class XMLFormat<T> {
          * (for J2ME compatibility).
          *
          * @param text the element text content or an empty sequence if none.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void addText(String text) throws XMLStreamException {
             _writer.writeCharacters(text);
@@ -852,7 +852,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the attribute name.
          * @param  value the attribute value or <code>null</code>.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, CharSequence value)
                 throws XMLStreamException {
@@ -867,7 +867,7 @@ public abstract class XMLFormat<T> {
          *
          * @param  name the attribute name.
          * @param  value the attribute value.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, String value)
                 throws XMLStreamException {
@@ -881,7 +881,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>boolean</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, boolean value)
                 throws XMLStreamException {
@@ -895,7 +895,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>char</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, char value)
                 throws XMLStreamException {
@@ -908,7 +908,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>byte</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, byte value)
                 throws XMLStreamException {
@@ -920,7 +920,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>short</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, short value)
                 throws XMLStreamException {
@@ -932,7 +932,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>int</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, int value)
                 throws XMLStreamException {
@@ -944,7 +944,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>long</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, long value)
                 throws XMLStreamException {
@@ -956,7 +956,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>float</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, float value)
                 throws XMLStreamException {
@@ -968,7 +968,7 @@ public abstract class XMLFormat<T> {
          * 
          * @param  name the attribute name.
          * @param  value the <code>double</code> value for the specified attribute.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, double value)
                 throws XMLStreamException {
@@ -977,12 +977,12 @@ public abstract class XMLFormat<T> {
 
         /**
          * Sets the specified attribute using its associated 
-         * {@link javolution.text.TextFormat TextFormat}.
+         * {@link org.javolution.text.TextFormat TextFormat}.
          * 
          * @param  name the name of the attribute.
          * @param  value the value for the specified attribute
          *         or <code>null</code> in which case the attribute is not set.
-         * @throws javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
+         * @throws org.javolution.xml.stream.XMLStreamException if and error occurs writing the xml stream
          */
         public void setAttribute(String name, Object value)
                 throws XMLStreamException {

--- a/src/main/java/org/javolution/xml/XMLObjectReader.java
+++ b/src/main/java/org/javolution/xml/XMLObjectReader.java
@@ -59,7 +59,7 @@ public class XMLObjectReader {
      * 
      * @param in the input stream.
      * @return Instance of an XMLObjectReader for this InputStream
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      */
     public static XMLObjectReader newInstance(InputStream in)
             throws XMLStreamException {
@@ -75,7 +75,7 @@ public class XMLObjectReader {
      * @param in the input stream.
      * @param encoding the input stream encoding
      * @return Instance of an XMLObjectReader for this InputStream with the given encoding
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      */
     public static XMLObjectReader newInstance(InputStream in, String encoding)
             throws XMLStreamException {
@@ -90,7 +90,7 @@ public class XMLObjectReader {
      * 
      * @param in the reader source.
      * @return Instance of an XMLObjectReader for this Reader
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      */
     public static XMLObjectReader newInstance(Reader in)
             throws XMLStreamException {
@@ -120,7 +120,7 @@ public class XMLObjectReader {
      * 
      * @param  in the source input stream.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      * @see    XMLStreamReaderImpl#setInput(InputStream)
      */
     public XMLObjectReader setInput(InputStream in) throws XMLStreamException {
@@ -137,7 +137,7 @@ public class XMLObjectReader {
      * @param in the input source.
      * @param encoding the associated encoding.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      * @see    XMLStreamReaderImpl#setInput(InputStream, String)
      */
     public XMLObjectReader setInput(InputStream in, String encoding)
@@ -154,7 +154,7 @@ public class XMLObjectReader {
      * 
      * @param  in the source reader.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs setting the input stream
      * @see    XMLStreamReaderImpl#setInput(Reader)
      */
     public XMLObjectReader setInput(Reader in) throws XMLStreamException {
@@ -196,7 +196,7 @@ public class XMLObjectReader {
      *
      * @return <code>true</code> if more element/data to be read; 
      *         <code>false</code> otherwise.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs reading the input
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs reading the input
      * @see    XMLFormat.InputElement#hasNext()
      */
     public boolean hasNext() throws XMLStreamException {
@@ -224,7 +224,7 @@ public class XMLObjectReader {
      * @param name the local name of the next element.
      * @return the next content object or <code>null</code> if the 
      *         local name does not match.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
      * @see    XMLFormat.InputElement#get(String)
      */
     @SuppressWarnings("unchecked")
@@ -241,7 +241,7 @@ public class XMLObjectReader {
      * @param uri the namespace URI.
      * @return the next content object or <code>null</code> if the 
      *         name/uri does not match.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
      * @see    XMLFormat.InputElement#get(String, String)
      */
     @SuppressWarnings("unchecked")
@@ -258,7 +258,7 @@ public class XMLObjectReader {
      * @param name the name of the element to match.
      * @param cls the non-abstract class identifying the object to return.
      * @return <code>read(name, null, cls)</code>
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
      */
     public <T> T read(String name, Class<T> cls) throws XMLStreamException {
         return _xml.get(name, cls);
@@ -274,7 +274,7 @@ public class XMLObjectReader {
      * @param uri the namespace URI.
      * @param cls the non-abstract class identifying the object to return.
      * @return the next content object or <code>null</code> if no match.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs while reading the input stream
      */
     public <T> T read(String localName, String uri, Class<T> cls)
             throws XMLStreamException {
@@ -284,7 +284,7 @@ public class XMLObjectReader {
     /**
      * Closes this reader and its underlying input then {@link #reset reset}
      * this reader for potential reuse.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs closing the input stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs closing the input stream
      */
     public void close() throws XMLStreamException {
         try {

--- a/src/main/java/org/javolution/xml/XMLObjectWriter.java
+++ b/src/main/java/org/javolution/xml/XMLObjectWriter.java
@@ -65,7 +65,7 @@ public class XMLObjectWriter {
      * 
      * @param out the output stream.
      * @return XMLObjectWriter instance for this OutputStream
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      */
     public static XMLObjectWriter newInstance(OutputStream out)
             throws XMLStreamException {
@@ -81,7 +81,7 @@ public class XMLObjectWriter {
      * @param out the output stream.
      * @param encoding the output stream encoding.
      * @return XMLObjectWriter instance for this OutputStream and Encoding
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      */
     public static XMLObjectWriter newInstance(OutputStream out, String encoding)
             throws XMLStreamException {
@@ -96,7 +96,7 @@ public class XMLObjectWriter {
      * 
      * @param out the writer output.
      * @return XMLObjectWriter instance for this Writer
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      */
     public static XMLObjectWriter newInstance(Writer out)
             throws XMLStreamException {
@@ -123,7 +123,7 @@ public class XMLObjectWriter {
      * 
      * @param  out the output stream destination.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      * @see    XMLStreamWriterImpl#setOutput(OutputStream)
      */
     public XMLObjectWriter setOutput(OutputStream out)
@@ -142,7 +142,7 @@ public class XMLObjectWriter {
      * @param  out the output stream destination.
      * @param  encoding the stream encoding.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      * @see    XMLStreamWriterImpl#setOutput(OutputStream, String)
      */
     public XMLObjectWriter setOutput(OutputStream out, String encoding)
@@ -160,7 +160,7 @@ public class XMLObjectWriter {
      * 
      * @param  out the writer destination.
      * @return <code>this</code>
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while setting the output stream
      * @see    XMLStreamWriterImpl#setOutput(Writer)
      */
     public XMLObjectWriter setOutput(Writer out) throws XMLStreamException {
@@ -214,7 +214,7 @@ public class XMLObjectWriter {
      * identified by the element name.
      *
      * @param obj the object written as nested element or <code>null</code>.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
      * @see   XMLFormat.OutputElement#add(Object)
      */
     public void write(Object obj) throws XMLStreamException {
@@ -228,7 +228,7 @@ public class XMLObjectWriter {
      *
      * @param obj the object added as nested element or <code>null</code>.
      * @param name the name of the nested element.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
      * @see   XMLFormat.OutputElement#add(Object, String)
      */
     public void write(Object obj, String name) throws XMLStreamException {
@@ -244,7 +244,7 @@ public class XMLObjectWriter {
      * @param obj the object added as nested element or <code>null</code>.
      * @param localName the local name of the nested element.
      * @param uri the namespace URI of the nested element.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
      * @see   XMLFormat.OutputElement#add(Object, String, String)
      */
     public void write(Object obj, String localName, String uri)
@@ -260,7 +260,7 @@ public class XMLObjectWriter {
      * @param obj the object added as nested element or <code>null</code>.
      * @param name the name of the nested element.
      * @param cls the non-abstract class identifying the XML format to use.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
      * @see   XMLFormat.OutputElement#add(Object, String, Class)
      */
     public <T> void write(T obj, String name, Class<T> cls)
@@ -277,7 +277,7 @@ public class XMLObjectWriter {
      * @param localName the local name of the nested element.
      * @param uri the namespace URI of the nested element.
      * @param cls the class identifying the XML format to use.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while writing the output
      * @see   XMLFormat.OutputElement#add(Object, String, String, Class)
      */
     public <T> void write(T obj, String localName, String uri, Class<T> cls)
@@ -288,7 +288,7 @@ public class XMLObjectWriter {
     /**
      * Flushes the output stream of this writer (automatically done 
      * when {@link #close() closing}).
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while flushing the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while flushing the output stream
      */
     public void flush() throws XMLStreamException {
         _xml._writer.flush();
@@ -297,7 +297,7 @@ public class XMLObjectWriter {
     /**
      * Ends document writting, closes this writer and its underlying 
      * output then {@link #reset reset} this Writer for potential reuse.
-     * @throws javolution.xml.stream.XMLStreamException if an exception occurs while closing the output stream
+     * @throws org.javolution.xml.stream.XMLStreamException if an exception occurs while closing the output stream
      */
     public void close() throws XMLStreamException {
         try {

--- a/src/main/java/org/javolution/xml/internal/XMLContextImpl.java
+++ b/src/main/java/org/javolution/xml/internal/XMLContextImpl.java
@@ -164,14 +164,14 @@ public final class XMLContextImpl extends XMLContext {
     /**
      * The default XML representation for {@link java.util.Map} consists of 
      * key/value pair as nested XML elements. For example:[code]
-     * <javolution.util.FastMap>
+     * <org.javolution.util.FastMap>
      *     <Key class="java.lang.String" value="ONE"/>
      *     <Value class="java.lang.Integer" value="1"/>
      *     <Key class="java.lang.String" value="TWO"/>
      *     <Value class="java.lang.Integer" value="2"/>
      *     <Key class="java.lang.String" value="THREE"/>
      *     <Value class="java.lang.Integer" value="3"/>
-     * </javolution.util.FastMap>[/code]
+     * </org.javolution.util.FastMap>[/code]
      *
      * The elements' order is defined by the map's entries iterator order.
      * Maps are deserialized using their default constructor.

--- a/src/main/java/org/javolution/xml/internal/stream/XMLStreamReaderImpl.java
+++ b/src/main/java/org/javolution/xml/internal/stream/XMLStreamReaderImpl.java
@@ -815,11 +815,6 @@ public final class XMLStreamReaderImpl implements XMLStreamReader {
 
     /**
      * Reloads data buffer.
-     * 
-     * @param detectEndOfStream indicates 
-     * @return <code>true</code> if the buffer has been reloaded;
-     *         <code>false</code> if the end of stream has being reached
-     *         and the event type (CHARACTERS or END_DOCUMENT) has been set.
      */
     private void reloadBuffer() throws XMLStreamException {
         if (_reader == null)

--- a/src/main/java/org/javolution/xml/internal/stream/XMLStreamReaderImpl.java
+++ b/src/main/java/org/javolution/xml/internal/stream/XMLStreamReaderImpl.java
@@ -265,9 +265,9 @@ public final class XMLStreamReaderImpl implements XMLStreamReader {
      * This method reads the prolog (if any).
      *
      * @param  reader the input source reader.
-     * @see    javolution.io.UTF8StreamReader
-     * @see    javolution.io.UTF8ByteBufferReader
-     * @see    javolution.io.CharSequenceReader
+     * @see    org.javolution.io.UTF8StreamReader
+     * @see    org.javolution.io.UTF8ByteBufferReader
+     * @see    org.javolution.io.CharSequenceReader
      */
     public void setInput(Reader reader) throws XMLStreamException {
         if (_reader != null)

--- a/src/main/java/org/javolution/xml/internal/stream/XMLStreamWriterImpl.java
+++ b/src/main/java/org/javolution/xml/internal/stream/XMLStreamWriterImpl.java
@@ -200,9 +200,9 @@ public final class XMLStreamWriterImpl implements XMLStreamWriter {
      * Sets the writer output destination for this XML stream writer. 
      *
      * @param  writer the output destination writer.
-     * @see    javolution.io.UTF8StreamWriter
-     * @see    javolution.io.UTF8ByteBufferWriter
-     * @see    javolution.io.AppendableWriter
+     * @see    org.javolution.io.UTF8StreamWriter
+     * @see    org.javolution.io.UTF8ByteBufferWriter
+     * @see    org.javolution.io.AppendableWriter
      */
     public void setOutput(Writer writer) throws XMLStreamException {
         if (_writer != null)

--- a/src/main/java/org/javolution/xml/package-info.java
+++ b/src/main/java/org/javolution/xml/package-info.java
@@ -17,10 +17,10 @@ Webhostinghub.com/support/edu</a>.</i></p>
 <ul>
     <li> Real-time characteristics with no adverse effect on memory footprint or 
  garbage collection (e.g. it can be used for time critical communications).
- {@link javolution.xml.XMLFormat XMLFormat} is basically a "smart" 
+ {@link org.javolution.xml.XMLFormat XMLFormat} is basically a "smart"
  wrapper around our real-time StAX-like
- {@link javolution.xml.stream.XMLStreamReader XMLStreamReader} and 
- {@link javolution.xml.stream.XMLStreamWriter XMLStreamWriter}.</li>
+ {@link org.javolution.xml.stream.XMLStreamReader XMLStreamReader} and
+ {@link org.javolution.xml.stream.XMLStreamWriter XMLStreamWriter}.</li>
     <li> Works directly with your existing Java classes, no need to create new classes
  or customize your implementation in any way.</li>
     <li> The XML representation can be high level and impervious to obfuscation
@@ -35,7 +35,7 @@ Webhostinghub.com/support/edu</a>.</i></p>
 
 
 <p> The default XML format for a class is typically defined using 
-    the {@link javolution.xml.DefaultXMLFormat} annotation tag. 
+    the {@link org.javolution.xml.DefaultXMLFormat} annotation tag.
 {@code
 {@literal@}DefaultXMLFormat(Graphic.XML.class)     
 public abstract class Graphic implements XMLSerializable {
@@ -297,10 +297,10 @@ System.out.println(xml);
 
 <B>ALGORITHMS:</B>
 
-<p> Our {@link javolution.xml.XMLObjectReader XMLObjectReader}/{@link javolution.xml.XMLObjectWriter XMLObjectWriter} 
+<p> Our {@link org.javolution.xml.XMLObjectReader XMLObjectReader}/{@link org.javolution.xml.XMLObjectWriter XMLObjectWriter}
     are in fact simple wrappers around our <b>J</b>avolution high-performance StAX-like
-    {@link javolution.xml.stream.XMLStreamReader XMLStreamReader} and 
-    {@link javolution.xml.stream.XMLStreamWriter XMLStreamWriter} classes. 
+    {@link org.javolution.xml.stream.XMLStreamReader XMLStreamReader} and
+    {@link org.javolution.xml.stream.XMLStreamWriter XMLStreamWriter} classes.
     The logic of these wrappers is described below:</p>
 <pre>
 

--- a/src/main/java/org/javolution/xml/sax/DefaultHandler.java
+++ b/src/main/java/org/javolution/xml/sax/DefaultHandler.java
@@ -96,7 +96,7 @@ public class DefaultHandler implements ContentHandler, ErrorHandler {
      *     correctly overriden.  This method generates a compile-error
      *     <code>"final method cannot be overridden"</code> if
      *     <code>org.xml.sax.Attributes</code> is used instead of
-     *     <code>javolution.xml.sax.Attributes</code> (common mistake).</p>
+     *     <code>org.javolution.xml.sax.Attributes</code> (common mistake).</p>
      * @param  uri the namespace URI, or an empty character sequence if the
      *         element has no Namespace URI or if namespace processing is not
      *         being performed.

--- a/src/main/java/org/javolution/xml/sax/SAX2ReaderImpl.java
+++ b/src/main/java/org/javolution/xml/sax/SAX2ReaderImpl.java
@@ -29,11 +29,11 @@ import java.lang.CharSequence;
 
 /**
  * <p> This class provides a SAX2-compliant parser wrapping a
- *     {@link javolution.xml.sax.XMLReaderImpl}. This parser allocates 
+ *     {@link org.javolution.xml.sax.XMLReaderImpl}. This parser allocates
  *     <code>java.lang.String</code> instances while parsing in accordance 
  *     with the SAX2 specification. For faster performance (2-5x), the use of 
- *     the SAX2-like {@link javolution.xml.sax.XMLReaderImpl 
- *     XMLSaxParserImpl} or better{@link javolution.xml.stream.XMLStreamReader 
+ *     the SAX2-like {@link org.javolution.xml.sax.XMLReaderImpl
+ *     XMLSaxParserImpl} or better{@link org.javolution.xml.stream.XMLStreamReader
  *     XMLStreamReader} is recommended.</p>
  *
  * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>

--- a/src/main/java/org/javolution/xml/sax/XMLReaderImpl.java
+++ b/src/main/java/org/javolution/xml/sax/XMLReaderImpl.java
@@ -280,7 +280,7 @@ public class XMLReaderImpl implements XMLReader {
      * 
      * @throws SAXException any SAX exception, possibly wrapping another
      *         exception.
-     * @throws IOException an IO exception from the parser, possibly from
+     * @throws XMLStreamException an IO exception from the parser, possibly from
      *         a byte stream or character stream supplied by the application.
      */
     private void parseAll() throws XMLStreamException, SAXException {

--- a/src/main/java/org/javolution/xml/sax/XMLReaderImpl.java
+++ b/src/main/java/org/javolution/xml/sax/XMLReaderImpl.java
@@ -134,9 +134,9 @@ public class XMLReaderImpl implements XMLReader {
      *         exception.
      * @throws IOException an IO exception from the parser, possibly from
      *         a byte stream or character stream supplied by the application.
-     * @see    javolution.io.UTF8StreamReader
-     * @see    javolution.io.UTF8ByteBufferReader
-     * @see    javolution.io.CharSequenceReader
+     * @see    org.javolution.io.UTF8StreamReader
+     * @see    org.javolution.io.UTF8ByteBufferReader
+     * @see    org.javolution.io.CharSequenceReader
      */
     public void parse(Reader reader) throws IOException, SAXException {
         try {

--- a/src/main/java/org/javolution/xml/sax/package-info.java
+++ b/src/main/java/org/javolution/xml/sax/package-info.java
@@ -1,6 +1,6 @@
 /**
-<p> {@link javolution.xml.sax.SAX2ReaderImpl SAX2} and high-performance
-    {@link javolution.xml.sax.XMLReaderImpl SAX2-Like} parsers. The later
+<p> {@link org.javolution.xml.sax.SAX2ReaderImpl SAX2} and high-performance
+    {@link org.javolution.xml.sax.XMLReaderImpl SAX2-Like} parsers. The later
     being several times faster than conventional SAX2 parsers (by avoiding 
     <code>String</code> allocations while parsing).</p>
  */

--- a/src/main/java/org/javolution/xml/stream/XMLInputFactory.java
+++ b/src/main/java/org/javolution/xml/stream/XMLInputFactory.java
@@ -18,7 +18,7 @@ import java.io.Reader;
  *     individually configured (if not enough the factory can be 
  *     {@link #clone cloned}). 
  * {@code
- * import javolution.xml.stream.*;
+ * import org.javolution.xml.stream.*;
  * public class Activator implements BundleActivator { 
  *     public void start(BundleContext bc) throws Exception {
  *     
@@ -55,12 +55,12 @@ public interface XMLInputFactory extends Cloneable {
      * The property that requires the parser to coalesce adjacent character data
      * sections.
      */
-    public static final String IS_COALESCING = "javolution.xml.stream.isCoalescing";
+    public static final String IS_COALESCING = "org.javolution.xml.stream.isCoalescing";
 
     /**
      * The property that requires the parser to validate the input data.
      */
-    public static final String IS_VALIDATING = "javolution.xml.stream.isValidating";
+    public static final String IS_VALIDATING = "org.javolution.xml.stream.isValidating";
 
     /**
      * Property used to specify additional entities to be recognized by the 
@@ -75,7 +75,7 @@ public interface XMLInputFactory extends Cloneable {
      *     factory.setProperty(ENTITIES, HTML_ENTITIES);
      * [/code]
      */
-    public static final String ENTITIES = "javolution.xml.stream.entities";
+    public static final String ENTITIES = "org.javolution.xml.stream.entities";
 
     /**
      * Returns a XML stream reader for the specified I/O reader.

--- a/src/main/java/org/javolution/xml/stream/XMLOutputFactory.java
+++ b/src/main/java/org/javolution/xml/stream/XMLOutputFactory.java
@@ -17,7 +17,7 @@ import java.io.Writer;
  *     individually configured  (if not enough the factory can be 
  *     {@link #clone cloned}).
  * {@code
- * import javolution.xml.stream.*;
+ * import org.javolution.xml.stream.*;
  * public class Activator implements BundleActivator { 
  *     public void start(BundleContext bc) throws Exception {
  *     
@@ -57,7 +57,7 @@ public interface XMLOutputFactory extends Cloneable {
      * Property used to set prefix defaulting on the output side
      * (type: <code>Boolean</code>, default: <code>FALSE</code>).
      */
-    public static final String IS_REPAIRING_NAMESPACES = "javolution.xml.stream.isRepairingNamespaces";
+    public static final String IS_REPAIRING_NAMESPACES = "org.javolution.xml.stream.isRepairingNamespaces";
 
     /**
      * Property used to specify the prefix to be appended by a trailing
@@ -65,20 +65,20 @@ public interface XMLOutputFactory extends Cloneable {
      * a temporary non-colliding prefix when repairing namespaces
      * (type: <code>String</code>, default: <code>"ns"</code>).
      */
-    public final static String REPAIRING_PREFIX = "javolution.xml.stream.repairingPrefix";
+    public final static String REPAIRING_PREFIX = "org.javolution.xml.stream.repairingPrefix";
 
     /**
      * Property used to specify an indentation string; non-null indentation 
      * forces the writer to write elements into separate lines
      * (type: <code>String</code>, default: <code>null</code>).
      */
-    public static final String INDENTATION = "javolution.xml.stream.indentation";
+    public static final String INDENTATION = "org.javolution.xml.stream.indentation";
 
     /**
     * Property used to specify the new line characters
     * (type: <code>String</code>, default: <code>"\n"</code>).
     */
-    public static final String LINE_SEPARATOR = "javolution.xml.stream.lineSeparator";
+    public static final String LINE_SEPARATOR = "org.javolution.xml.stream.lineSeparator";
 
     /**
      * Property indicating if the stream writers are allowed to automatically 
@@ -86,7 +86,7 @@ public interface XMLOutputFactory extends Cloneable {
      * matching end element
      * (type: <code>Boolean</code>, default: <code>FALSE</code>).
      */
-    public final static String AUTOMATIC_EMPTY_ELEMENTS = "javolution.xml.stream.automaticEmptyElements";
+    public final static String AUTOMATIC_EMPTY_ELEMENTS = "org.javolution.xml.stream.automaticEmptyElements";
 
     /**
      * Property indicating if the stream writers are not allowed to use 
@@ -96,7 +96,7 @@ public interface XMLOutputFactory extends Cloneable {
      * (e.g. i.e. "&lt;empty /&gt;" replaced by  "&lt;empty&gt;&lt;/empty&gt;"),
      * This property takes precedence over {@link #AUTOMATIC_EMPTY_ELEMENTS}.
      */
-    public final static String NO_EMPTY_ELEMENT_TAG = "javolution.xml.stream.noEmptyElementTag";
+    public final static String NO_EMPTY_ELEMENT_TAG = "org.javolution.xml.stream.noEmptyElementTag";
 
     /**
      * Returns a XML stream writer to the specified i/o writer.

--- a/src/main/java/org/javolution/xml/stream/XMLStreamReader.java
+++ b/src/main/java/org/javolution/xml/stream/XMLStreamReader.java
@@ -461,9 +461,9 @@ public interface XMLStreamReader extends XMLStreamConstants {
      * @param length the number of characters to copy
      * @return the number of characters actually copied
      * @throws XMLStreamException if the XML source is not well-formed.
-     * @throws IndexOutOfBoundsException
+     * @throws IndexOutOfBoundsException if
      *             {@code if targetStart < 0 or > than the length of target}
-     * @throws IndexOutOfBoundsException
+     * @throws IndexOutOfBoundsException if
      *             {@code if length < 0 or targetStart + length > length of target}
      * @throws UnsupportedOperationException if this method is not supported.
      */

--- a/src/main/java/org/javolution/xml/stream/XMLStreamWriter.java
+++ b/src/main/java/org/javolution/xml/stream/XMLStreamWriter.java
@@ -21,7 +21,7 @@ import java.lang.CharSequence;
  *     
  * <p> This writer does not require creating new <code>String</code> objects 
  *     during XML formatting. Attributes values can be held by a single/reusable
- *     {@link javolution.text.TextBuilder TextBuilder}  
+ *     {@link org.javolution.text.TextBuilder TextBuilder}
  *     (or <code>StringBuilder</code>) instance to avoid adverse effects 
  *     on memory footprint (heap), garbage collection and performance.
  * {@code

--- a/src/main/java/org/javolution/xml/stream/package-info.java
+++ b/src/main/java/org/javolution/xml/stream/package-info.java
@@ -8,8 +8,8 @@
     existing StAX code requires very little modification to be used with these 
     new classes.</p>
 <p> For more information about the usage of this package please read the 
-    documentation for the {@link javolution.xml.stream.XMLStreamReader} and 
-    {@link javolution.xml.stream.XMLStreamWriter} interfaces.</p>
+    documentation for the {@link org.javolution.xml.stream.XMLStreamReader} and
+    {@link org.javolution.xml.stream.XMLStreamWriter} interfaces.</p>
 <p> For more information about StAX (Streaming API for XML) in general see 
     <a href="http://en.wikipedia.org/wiki/StAX">Wikipedia: StAX</a></p>
  */

--- a/src/main/java/org/javolution/xml/ws/WebServiceClient.java
+++ b/src/main/java/org/javolution/xml/ws/WebServiceClient.java
@@ -24,7 +24,7 @@ import org.javolution.xml.stream.XMLStreamWriter;
  * <p> This class provides a simple web service client capable of leveraging  
  *     Javolution XML marshalling/unmarshalling.</p>
  *     
- * <p> Sub-classes may work from WSDL files, {@link javolution.xml.XMLFormat
+ * <p> Sub-classes may work from WSDL files, {@link org.javolution.xml.XMLFormat
  *     XMLFormat} or directly with the XML streams (StAX). For example:{@code
  *     private static class HelloWorld extends WebServiceClient  {
  *         protected void writeRequest(XMLObjectWriter out) throws XMLStreamException {
@@ -88,7 +88,7 @@ public abstract class WebServiceClient {
     /**
      * Invokes the web service.
      * @throws java.io.IOException if an error occurs opening the connection
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs writing the payload
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs writing the payload
      */
     public void invoke() throws IOException, XMLStreamException {
         try {
@@ -162,7 +162,7 @@ public abstract class WebServiceClient {
      * Writes the web service request (SOAP body).
      * 
      * @param out the XML object writer.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs writing the payload
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs writing the payload
      */
     protected abstract void writeRequest(XMLObjectWriter out)
             throws XMLStreamException;
@@ -172,7 +172,7 @@ public abstract class WebServiceClient {
      * writes the body XML events to <code>System.out</code>.
      * 
      * @param in the XML object reader.
-     * @throws javolution.xml.stream.XMLStreamException if an error occurs reading the payload
+     * @throws org.javolution.xml.stream.XMLStreamException if an error occurs reading the payload
      */
     protected void readResponse(XMLObjectReader in) throws XMLStreamException {
         final XMLStreamReader xml = in.getStreamReader();


### PR DESCRIPTION
Fix most of javadoc errors and links in comments and html in many places.  
Replaced by regex From: "(?<!org\.)(javolution\.)(?!org)" To: "org\.$1"